### PR TITLE
Refactor: Extend ipython-sql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,11 @@ jobs:
     - run: curl -s -S --retry 3 $BASEDIR/tests/install.sh | bash -
     - run: pip install .[test]
     - run: curl -s -S --retry 3 $BASEDIR/tests/script.sh | bash -
-    - run: pytest --cov ocdskingfishercolab
+    # The unit tests need to be run with ipython, as the code requires a
+    # running ipython instance (as you would have in a notebook)
+    - run: ipython -m pytest -- --cov ocdskingfishercolab
       env:
-        DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres
+        TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres
       if: always()
     - env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,19 +7,17 @@ Changelog
 Changed
 ~~~~~~~
 
-- Refactor to build upon `ipython-sql <https://pypi.org/project/ipython-sql/>`__.
-  Removes several functions that can be replaced with direct usage of ipython-sql magics in the notebook,
-  and replace all remaining sql calls with calls to ipython-sql.
+-  Refactor to build upon `ipython-sql <https://pypi.org/project/ipython-sql/>`__.
+   Removes several functions that can be replaced with direct usage of ipython-sql magics in the notebook, and replace all remaining sql calls with calls to ipython-sql.
 
-  Replacements (must run ``%load_ext sql`` first, and ``%config SqlMagic.autopandas = True`` to get a pandas ``DataFrame``):
+   Replacements (must run ``%load_ext sql`` first, and ``%config SqlMagic.autopandas = True`` to get a pandas ``DataFrame``):
 
-  * :meth:`ocdskingfishercolab.create_connection` — replaced by using an ipython-sql connection string, e.g. ``%sql postgresql://user:pass@host/db``
-  * :meth:`ocdskingfishercolab.execute_statement`, :meth:`ocdskingfishercolab.get_dataframe_from_cursor` and
-    :meth:`ocdskingfishercolab.get_dataframe_from_query` — replaced by ipython-sql's ``%sql`` magic, e.g. ``%sql SELECT a FROM b``
-  * :meth:`ocdskingfishercolab.get_list_from_query` — replaced by :meth:`get_ipython_sql_resultset_from_query`. This returns an ipython-sql ResultSet, which can behave broadly like a list, but also has other features.
-  * :meth:`ocdskingfishercolab.download_package_from_query` no longer takes a ``params`` argument, and instead uses variables from the local scope, to be consisent with the ipython-sql's ``%sql`` magic.
+   -  :meth:`ocdskingfishercolab.create_connection` — replaced by using an ipython-sql connection string, e.g. ``%sql postgresql://user:pass@host/db``
+   -  :meth:`ocdskingfishercolab.execute_statement`, :meth:`ocdskingfishercolab.get_dataframe_from_cursor` and :meth:`ocdskingfishercolab.get_dataframe_from_query` — replaced by ipython-sql's ``%sql`` magic, e.g. ``%sql SELECT a FROM b``
+   -  :meth:`ocdskingfishercolab.get_list_from_query` — replaced by :meth:`get_ipython_sql_resultset_from_query`. This returns an ipython-sql ResultSet, which can behave broadly like a list, but also has other features.
+   -  :meth:`ocdskingfishercolab.download_package_from_query` no longer takes a ``params`` argument, and instead uses variables from the local scope, to be consisent with the ipython-sql's ``%sql`` magic.
 
-  There's a shared (but not public) `colab notebook of examples run against live kingfisher <https://colab.research.google.com/drive/1cUYY4on72831DPSiQ_JLxJEY2uGTfVrN#scrollTo=I-QPDbliMVXC>`__.
+   There's a shared (but not public) `colab notebook of examples run against live kingfisher <https://colab.research.google.com/drive/1cUYY4on72831DPSiQ_JLxJEY2uGTfVrN#scrollTo=I-QPDbliMVXC>`__.
 
 0.2.3 (Unreleased)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,10 +14,10 @@ Changed
   Replacements (must run ``%load_ext sql`` first, and ``%config SqlMagic.autopandas = True`` to get a pandas ``DataFrame``):
 
   * :meth:`ocdskingfishercolab.create_connection` — replaced by using an ipython-sql connection string, e.g. ``%sql postgresql://user:pass@host/db``
-  * :meth:`ocdskingfishercolab.execute_statment`, :meth:`ocdskingfishercolab.get_dataframe_from_cursor` and
-    :meth:`ocdskingfishercolab.get_dataframe_from_query` — replaced by sql magic from ipython-sql, e.g. ``%sql SELECT a FROM b``
+  * :meth:`ocdskingfishercolab.execute_statement`, :meth:`ocdskingfishercolab.get_dataframe_from_cursor` and
+    :meth:`ocdskingfishercolab.get_dataframe_from_query` — replaced by ipython-sql's ``%sql`` magic, e.g. ``%sql SELECT a FROM b``
   * :meth:`ocdskingfishercolab.get_list_from_query` — replaced by :meth:`get_ipython_sql_resultset_from_query`. This returns an ipython-sql ResultSet, which can behave broadly like a list, but also has other features.
-  * :meth:`ocdskingfishercolab.download_package_from_query` has lost the params argument, and will pull variables from the local scope instead (to be consisent with the ipython-sql sql magic).
+  * :meth:`ocdskingfishercolab.download_package_from_query` no longer takes a ``params`` argument, and instead uses variables from the local scope, to be consisent with the ipython-sql's ``%sql`` magic.
 
   There's a shared (but not public) `colab notebook of examples run against live kingfisher <https://colab.research.google.com/drive/1cUYY4on72831DPSiQ_JLxJEY2uGTfVrN#scrollTo=I-QPDbliMVXC>`__.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,9 +12,9 @@ Changed
 
    Replacements (must run ``%load_ext sql`` first, and ``%config SqlMagic.autopandas = True`` to get a pandas ``DataFrame``):
 
-   -  :meth:`ocdskingfishercolab.create_connection` — replaced by using an ipython-sql connection string, e.g. ``%sql postgresql://user:pass@host/db``
-   -  :meth:`ocdskingfishercolab.execute_statement`, :meth:`ocdskingfishercolab.get_dataframe_from_cursor` and :meth:`ocdskingfishercolab.get_dataframe_from_query` — replaced by ipython-sql's ``%sql`` magic, e.g. ``%sql SELECT a FROM b``
-   -  :meth:`ocdskingfishercolab.get_list_from_query` — replaced by :meth:`get_ipython_sql_resultset_from_query`. This returns an ipython-sql ResultSet, which can behave broadly like a list, but also has other features.
+   -  ``ocdskingfishercolab.create_connection`` — replaced by using an ipython-sql connection string, e.g. ``%sql postgresql://user:pass@host/db``
+   -  ``ocdskingfishercolab.execute_statement``, ``ocdskingfishercolab.get_dataframe_from_cursor`` and ``ocdskingfishercolab.get_dataframe_from_query`` — replaced by ipython-sql's ``%sql`` magic, e.g. ``%sql SELECT a FROM b``
+   -  ``ocdskingfishercolab.get_list_from_query`` — replaced by :meth:`ocdskingfishercolab.get_ipython_sql_resultset_from_query`. This returns an `ipython-sql ResultSet <https://pypi.org/project/ipython-sql/#examples>`__, the type returned by the ``%sql%`` magic when ``autopandas`` is off. It behaves like a list, but with extra methods.
    -  :meth:`ocdskingfishercolab.download_package_from_query` no longer takes a ``params`` argument, and instead uses variables from the local scope, to be consisent with the ipython-sql's ``%sql`` magic.
 
    There's a shared (but not public) `colab notebook of examples run against live kingfisher <https://colab.research.google.com/drive/1cUYY4on72831DPSiQ_JLxJEY2uGTfVrN#scrollTo=I-QPDbliMVXC>`__.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,26 @@
 Changelog
 =========
 
+0.3.0 (Unreleased)
+------------------
+
+Changed
+~~~~~~~
+
+- Refactor to build upon `ipython-sql <https://pypi.org/project/ipython-sql/>`__.
+  Removes several functions that can be replaced with direct usage of ipython-sql magics in the notebook,
+  and replace all remaining sql calls with calls to ipython-sql.
+
+  Replacements (must run ``%load_ext sql`` first, and ``%config SqlMagic.autopandas = True`` to get a pandas ``DataFrame``):
+
+  * :meth:`ocdskingfishercolab.create_connection` — replaced by using an ipython-sql connection string, e.g. ``%sql postgresql://user:pass@host/db``
+  * :meth:`ocdskingfishercolab.execute_statment`, :meth:`ocdskingfishercolab.get_dataframe_from_cursor` and
+    :meth:`ocdskingfishercolab.get_dataframe_from_query` — replaced by sql magic from ipython-sql, e.g. ``%sql SELECT a FROM b``
+  * :meth:`ocdskingfishercolab.get_list_from_query` — replaced by :meth:`get_ipython_sql_resultset_from_query`. This returns an ipython-sql ResultSet, which can behave broadly like a list, but also has other features.
+  * :meth:`ocdskingfishercolab.download_package_from_query` has lost the params argument, and will pull variables from the local scope instead (to be consisent with the ipython-sql sql magic).
+
+  There's a shared (but not public) `colab notebook of examples run against live kingfisher <https://colab.research.google.com/drive/1cUYY4on72831DPSiQ_JLxJEY2uGTfVrN#scrollTo=I-QPDbliMVXC>`__.
+
 0.2.3 (Unreleased)
 ------------------
 

--- a/ocdskingfishercolab/__init__.py
+++ b/ocdskingfishercolab/__init__.py
@@ -86,11 +86,11 @@ def set_spreadsheet_name(name):
 
 def list_source_ids(pattern=''):
     """
-    Returns, as a data frame, a list of source IDs matching the given pattern.
+    Returns, as a ResultSet or DataFrame, a list of source IDs matching the given pattern.
 
     :param str pattern: a substring, like "paraguay"
-    :returns: the results as a data frame
-    :rtype: pandas.DataFrame
+    :returns: the results as a pandas DataFrame or an ipython-sql `ResultSet <https://github.com/catherinedevlin/ipython-sql/blob/b24ac6e9410416eafde86ae22fd8d6f34acbe05d/src/sql/run.py#L99>`__, depending on whether ``%config SqlMagic.autopandas`` is ``True`` or ``False`` respectively. This is the same behaviour as ipython-sql's ``%sql`` magic.
+    :rtype: pandas.DataFrame or sql.run.ResultSet
     """
     sql = """
     SELECT source_id
@@ -108,11 +108,11 @@ def list_source_ids(pattern=''):
 
 def list_collections(source_id):
     """
-    Returns, as a data frame, a list of collections with the given source ID.
+    Returns, as a ResultSet or DataFrame, a list of collections with the given source ID.
 
     :param str source_id: a source ID
-    :returns: the results as a data frame
-    :rtype: pandas.DataFrame
+    :returns: the results as a pandas DataFrame or an ipython-sql `ResultSet <https://github.com/catherinedevlin/ipython-sql/blob/b24ac6e9410416eafde86ae22fd8d6f34acbe05d/src/sql/run.py#L99>`__, depending on whether ``%config SqlMagic.autopandas`` is ``True`` or ``False`` respectively. This is the same behaviour as ipython-sql's ``%sql`` magic.
+    :rtype: pandas.DataFrame or sql.run.ResultSet
     """
     sql = """
     SELECT *
@@ -132,7 +132,7 @@ def set_search_path(schema_name):
 
     :param str schema_name: a schema name
     """
-    return get_ipython().magic(f'sql SET search_path = {schema_name}, public')
+    get_ipython().magic(f'sql SET search_path = {schema_name}, public')
 
 
 def save_dataframe_to_sheet(dataframe, sheetname, prompt=True):
@@ -215,6 +215,16 @@ def download_data_as_json(data, filename):
 
 
 def get_ipython_sql_resultset_from_query(sql):
+    """
+    Executes a SQL statement and returns a ResultSet.
+
+    Parameters are taken from the scope this function is called from (same behaviour as ipython-sql's ``%sql`` magic).
+
+    :param str sql: a SQL statement
+    :returns: the results as a `ResultSet <https://github.com/catherinedevlin/ipython-sql/blob/b24ac6e9410416eafde86ae22fd8d6f34acbe05d/src/sql/run.py#L99>`__
+    :rtype: sql.run.ResultSet
+
+    """
     ipython = get_ipython()
     autopandas = ipython.magic('config SqlMagic.autopandas')
     if autopandas:

--- a/ocdskingfishercolab/__init__.py
+++ b/ocdskingfishercolab/__init__.py
@@ -226,6 +226,9 @@ def get_ipython_sql_resultset_from_query(sql):
     """  # noqa: E501
     ipython = get_ipython()
     autopandas = ipython.magic('config SqlMagic.autopandas')
+    # Disable autopandas, so we know that the sql magic call will always return
+    # a ResultSet (rather than a pandas DataFrame). Since the DataFrame would
+    # be created from the ResultSet, it would be less efficient.
     if autopandas:
         ipython.magic('config SqlMagic.autopandas=False')
     # Use ipython.run_line_magic instead of ipython.magic here
@@ -283,6 +286,9 @@ def download_package_from_ocid(collection_id, ocid, package_type):
 
     ipython = get_ipython()
     autopandas = ipython.magic('config SqlMagic.autopandas')
+    # Disable autopandas, so we know that the sql magic call will always return
+    # a ResultSet (rather than a pandas DataFrame). Since the DataFrame would
+    # be created from the ResultSet, it would be less efficient.
     if autopandas:
         ipython.magic('config SqlMagic.autopandas=False')
     # This inspects locals to find ocid and collection_id

--- a/ocdskingfishercolab/__init__.py
+++ b/ocdskingfishercolab/__init__.py
@@ -91,7 +91,7 @@ def list_source_ids(pattern=''):
     :param str pattern: a substring, like "paraguay"
     :returns: the results as a pandas DataFrame or an ipython-sql `ResultSet <https://github.com/catherinedevlin/ipython-sql/blob/b24ac6e9410416eafde86ae22fd8d6f34acbe05d/src/sql/run.py#L99>`__, depending on whether ``%config SqlMagic.autopandas`` is ``True`` or ``False`` respectively. This is the same behaviour as ipython-sql's ``%sql`` magic.
     :rtype: pandas.DataFrame or sql.run.ResultSet
-    """
+    """  # noqa: E501
     sql = """
     SELECT source_id
     FROM collection
@@ -113,7 +113,7 @@ def list_collections(source_id):
     :param str source_id: a source ID
     :returns: the results as a pandas DataFrame or an ipython-sql `ResultSet <https://github.com/catherinedevlin/ipython-sql/blob/b24ac6e9410416eafde86ae22fd8d6f34acbe05d/src/sql/run.py#L99>`__, depending on whether ``%config SqlMagic.autopandas`` is ``True`` or ``False`` respectively. This is the same behaviour as ipython-sql's ``%sql`` magic.
     :rtype: pandas.DataFrame or sql.run.ResultSet
-    """
+    """  # noqa: E501
     sql = """
     SELECT *
     FROM collection
@@ -223,8 +223,7 @@ def get_ipython_sql_resultset_from_query(sql):
     :param str sql: a SQL statement
     :returns: the results as a `ResultSet <https://github.com/catherinedevlin/ipython-sql/blob/b24ac6e9410416eafde86ae22fd8d6f34acbe05d/src/sql/run.py#L99>`__
     :rtype: sql.run.ResultSet
-
-    """
+    """  # noqa: E501
     ipython = get_ipython()
     autopandas = ipython.magic('config SqlMagic.autopandas')
     if autopandas:

--- a/ocdskingfishercolab/__init__.py
+++ b/ocdskingfishercolab/__init__.py
@@ -29,8 +29,7 @@ def run(conn, _sql, *args, **kwargs):
         comment = '/* https://colab.research.google.com/drive/{} */'.format(_notebook_id())
     except KeyError:
         comment = "/* run from a notebook, but no colab id */"
-    _sql = comment+_sql
-    return old_run(conn, _sql, *args, **kwargs)
+    return old_run(conn, comment + _sql, *args, **kwargs)
 
 
 sql.run.run = run
@@ -217,9 +216,7 @@ def download_data_as_json(data, filename):
 
 def get_ipython_sql_resultset_from_query(sql):
     ipython = get_ipython()
-    autopandas = False
-    if ipython.magic('config SqlMagic.autopandas'):
-        autopandas = True
+    autopandas = ipython.magic('config SqlMagic.autopandas')
     if autopandas:
         ipython.magic('config SqlMagic.autopandas=False')
     # Use ipython.run_line_magic instead of ipython.magic here
@@ -276,9 +273,7 @@ def download_package_from_ocid(collection_id, ocid, package_type):
     """
 
     ipython = get_ipython()
-    autopandas = False
-    if ipython.magic('config SqlMagic.autopandas'):
-        autopandas = True
+    autopandas = ipython.magic('config SqlMagic.autopandas')
     if autopandas:
         ipython.magic('config SqlMagic.autopandas=False')
     # This inspects locals to find ocid and collection_id

--- a/ocdskingfishercolab/__init__.py
+++ b/ocdskingfishercolab/__init__.py
@@ -217,6 +217,7 @@ def download_data_as_json(data, filename):
 
 def get_ipython_sql_resultset_from_query(sql):
     ipython = get_ipython()
+    autopandas = False
     if ipython.magic('config SqlMagic.autopandas'):
         autopandas = True
     if autopandas:

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,6 @@ setup(
         'libcoveocds',
         'notebook~=5.2.0',  # google-colab 1.0.0
         'oauth2client',
-        'pandas~=0.24.0',  # google-colab 1.0.0
-        'psycopg2-binary',
         'pydrive',
         'requests~=2.21.0',  # google-colab 1.0.0
         'ipython-sql~=0.4.0',
@@ -38,6 +36,8 @@ setup(
             'coveralls',
             'pytest',
             'pytest-cov',
+            'pandas~=0.24.0',  # google-colab 1.0.0
+            'psycopg2-binary',
         ],
         'docs': [
             'Sphinx',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'psycopg2-binary',
         'pydrive',
         'requests~=2.21.0',  # google-colab 1.0.0
+        'ipython-sql~=0.4.0',
         # https://github.com/googleapis/google-api-python-client/issues/870
         'google-api-python-client!=1.8.1,<1.9.0',  # google-colab 1.0.0 requires google-auth~=1.4.0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,10 +12,10 @@ from IPython import get_ipython
 # If this fixture becomes too slow, we can setup the database once, and run each test in a transaction.
 @pytest.fixture
 def db():
-    # Don't call this DATABASE_URL, as ipython-sql will try and use it, instaed of the created database url
+    # This can't be named DATABASE_URL, because ipython-sql will try and use it.
     database_url = os.getenv('TEST_DATABASE_URL', 'postgresql://{}:@localhost:5432/postgres'.format(getpass.getuser()))
-    created_database_url = re.sub('/[^/]*$', '/ocdskingfishercolab_test', database_url)
     parts = urlparse(database_url)
+    created_database_url = parts._replace(path='/ocdskingfishercolab_test').geturl()
     kwargs = {
         'user': parts.username,
         'password': parts.password,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,10 @@ def db():
             cur.close()
             conn.close()
     finally:
+        # Close ipython-sql's open connections, so that we can drop the database.
+        # We have to do this manually, because ipython-sql's own connection
+        # closing support is broken
+        # https://github.com/catherinedevlin/ipython-sql/issues/170
         for ipython_sql_connection in sql.connection.Connection.connections.values():
             ipython_sql_connection.session.close()
             ipython_sql_connection.session.engine.dispose()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import getpass
 import os
-import re
 from urllib.parse import urlparse
 
 import psycopg2


### PR DESCRIPTION
Adding this a draft. I've made all the changes I think I need, but still need to update tests etc.

Demo of this: https://colab.research.google.com/drive/1cUYY4on72831DPSiQ_JLxJEY2uGTfVrN (shared, but not public)

Description from the commit follows:

Removes several functions that can be replaced with direct usage of ipython-sql in the notebook, and replace all remaining sql calls with calls to ipython-sql. This means we'll use the same connection information as has been set for ipython-sql.

Also monkeypatches ipython-sql to add a comment to every sql query (as the previous code did).

https://github.com/open-contracting/kingfisher-colab/issues/29