### PR TITLE
Upgrade to psycopg (psycopg 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           cache-dependency-path: pyproject.toml
       - run: pip install .[test]
       - env:
-          TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres
+          TEST_DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres
           # https://jupyter-core.readthedocs.io/en/stable/changelog.html#migrate-to-standard-platform-directories
           JUPYTER_PLATFORM_DIRS: 1
         # The tests must be run with ipython. However, ipython always returns exit code 0.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /dist
 /docs/_build
 /htmlcov
+__pycache__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pandas",
-    "psycopg2-binary",
+    "psycopg[binary]",
     "pytest",
     "pytest-cov",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import getpass
 import os
 from urllib.parse import urlsplit
 
-import psycopg2
+import psycopg
 import pytest
 import sql
 from IPython import get_ipython
@@ -12,7 +12,7 @@ from IPython import get_ipython
 @pytest.fixture
 def db():
     # This can't be named DATABASE_URL, because ipython-sql will try and use it.
-    database_url = os.getenv("TEST_DATABASE_URL", f"postgresql://{getpass.getuser()}:@localhost:5432/postgres")
+    database_url = os.getenv("TEST_DATABASE_URL", f"postgresql+psycopg://{getpass.getuser()}:@localhost:5432/postgres")
     parsed = urlsplit(database_url)
     created_database_url = parsed._replace(path="/ocdskingfishercolab_test").geturl()
     kwargs = {
@@ -22,16 +22,15 @@ def db():
         "port": parsed.port,
     }
 
-    connection = psycopg2.connect(dbname=parsed.path[1:], **kwargs)
-    cursor = connection.cursor()
-
+    connection = psycopg.connect(dbname=parsed.path[1:], **kwargs)
     # Avoid "CREATE DATABASE cannot run inside a transaction block" error
-    connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+    connection.autocommit = True
+    cursor = connection.cursor()
 
     try:
         cursor.execute("CREATE DATABASE ocdskingfishercolab_test")
 
-        conn = psycopg2.connect(dbname="ocdskingfishercolab_test", **kwargs)
+        conn = psycopg.connect(dbname="ocdskingfishercolab_test", **kwargs)
         cur = conn.cursor()
 
         try:

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -269,9 +269,9 @@ def test_get_ipython_sql_resultset_from_query_error(db, capsys):
     get_ipython().run_line_magic("sql", "invalid")
 
     assert (
-        '(psycopg2.errors.SyntaxError) syntax error at or near "invalid"\n'
+        '(psycopg.errors.SyntaxError) syntax error at or near "invalid"\n'
         "LINE 1: ...google.com/drive/1lpWoGnOb6KcjHDEhSBjWZgA8aBLCfDp0 */invalid\n"
-        "                                                                ^\n\n"
+        "                                                                ^\n"
         "[SQL: /* https://colab.research.google.com/drive/1lpWoGnOb6KcjHDEhSBjWZgA8aBLCfDp0 */invalid]\n"
         "(Background on this error at: https://sqlalche.me/e/" in capsys.readouterr().out
     )


### PR DESCRIPTION
Replace psycopg2 with psycopg (psycopg 3):

- Use psycopg[binary] in the test extras.
- Update the test fixture: psycopg.connect(), connection.autocommit = True
  (replacing set_isolation_level with ISOLATION_LEVEL_AUTOCOMMIT).
- Route the SQLAlchemy (ipython-sql) URL through the postgresql+psycopg
  dialect so it doesn't default to psycopg2.
- Update the expected error-message text (psycopg.errors.SyntaxError, and
  psycopg 3's single newline before the [SQL: ...] line).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G9jzdAoPJ6TBTme4DFaP7b